### PR TITLE
Correctly handle collections with the same name

### DIFF
--- a/purviewautomation/collections.py
+++ b/purviewautomation/collections.py
@@ -235,11 +235,15 @@ class PurviewCollections:
 
             elif len(friendly_list) > 1:
                 for collection in friendly_list:
+                    found_name = ""
                     if collection[1]["parentCollection"] == parent_collection.lower():
-                        name = collection[0]
-                    else:
-                        if collection[0] == name:
-                            name = "".join(random.choices(string.ascii_lowercase, k=6))
+                        found_name = collection[0]
+                        break
+                if found_name != "":
+                    name = found_name
+                else:
+                    name = self._verify_collection_name(name)
+
             else:
                 name = self._verify_collection_name(name)
         else:


### PR DESCRIPTION
In the current code, there's a mistake in the logic which means where more than one collection exists with a given name, the code will iterate over attempting to find if it already exists. However, if no match is found, no Name is given and it retains the FriendlyName, even if that is not a valid name to set within Purview.

This update handles this case so that it takes the first total match to FriendlyName and ParentCollection or, on failing that, will run the _verify_collection_name script to ensure a valid name is given or generated.